### PR TITLE
Changing image size view model to make it work with Magento 2.4.1

### DIFF
--- a/ViewModel/ImageSize.php
+++ b/ViewModel/ImageSize.php
@@ -15,7 +15,7 @@ class ImageSize implements ArgumentInterface
     /**
      * @var DirectoryReadInterface
      */
-    private $pubDirectory;
+    private $mediaDirectory;
 
     public function __construct(Filesystem $filesystem)
     {
@@ -24,22 +24,23 @@ class ImageSize implements ArgumentInterface
 
     public function get(CategoryInterface $category): ?array
     {
-        if (!$category->getImage() || !$this->getPubDirectory()->isReadable($category->getImage())) {
+        if (!$category->getImage() || !$this->getMediaDirectory()->isReadable()) {
             return null;
         }
 
-        $imagePath = $this->getPubDirectory()->getAbsolutePath($category->getImage());
+	    $catImagePath = '/catalog/category/';
+	    $imagePath = $this->mediaDirectory->getAbsolutePath($catImagePath.$category->getImage());
         [$width, $height] = getimagesize($imagePath);
 
         return $width ? ['width' => $width, 'height' => $height] : null;
     }
 
-    private function getPubDirectory(): DirectoryReadInterface
+    private function getMediaDirectory(): DirectoryReadInterface
     {
-        if (!$this->pubDirectory) {
-            $this->pubDirectory = $this->filesystem->getDirectoryRead(DirectoryList::PUB);
+	    if (!$this->mediaDirectory) {
+		    $this->mediaDirectory = $this->filesystem->getDirectoryRead(DirectoryList::MEDIA);
         }
 
-        return $this->pubDirectory;
+	    return $this->mediaDirectory;
     }
 }


### PR DESCRIPTION
The view model didn't really work when installed in a Magento 2.4.1, haven't verified if it is a specific version issue, but the image path was not correct